### PR TITLE
Python 3.6 and 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 script: python runtests.py 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ library. Here's an example demonstrating the `aioprocessing` versions of
         lock = aioprocessing.AioLock()
         event = aioprocessing.AioEvent()
         tasks = [
-            asyncio.async(example(queue, event, lock)), 
-            asyncio.async(example2(queue, event, lock)),
+            asyncio.ensure_future(example(queue, event, lock)), 
+            asyncio.ensure_future(example2(queue, event, lock)),
         ]
         loop.run_until_complete(asyncio.wait(tasks))
         loop.close()
@@ -136,5 +136,4 @@ versions by adding coroutine versions of all the blocking methods.
 What versions of Python are compatible?
 ---------------------------------------
 
-`aioprocessing` will work out of the box on Python 3.4+, and will also work with Python
-3.3 if you install the [PyPI version](https://pypi.python.org/pypi/asyncio) of `asyncio`.
+`aioprocessing` will work out of the box on Python 3.4+

--- a/aioprocessing/managers.py
+++ b/aioprocessing/managers.py
@@ -21,7 +21,7 @@ class _AioProxyMixin(_ExecutorMixin):
     _obj = None
 
     def _async_call(self, method, *args, loop=None, **kwargs):
-        return asyncio.async(self.run_in_executor(self._callmethod, method, 
+        return asyncio.ensure_future(self.run_in_executor(self._callmethod, method,
                                                   args, kwargs, loop=loop))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-asyncio; python_version < '3.4'
+asyncio; python_version >= '3.4'

--- a/tests/lock_tests.py
+++ b/tests/lock_tests.py
@@ -319,7 +319,7 @@ class BarrierTest(BaseTest):
             yield from self.barrier.coro_wait()
 
         def wait_barrier():
-            fut = asyncio.async(wait_barrier_async())
+            fut = asyncio.ensure_future(wait_barrier_async())
             yield from asyncio.sleep(.5)
             self.assertEqual(1, self.barrier.n_waiting)
             self.barrier.wait()


### PR DESCRIPTION
asyncio.async doesn't exist on python 3.6+

I suggest remove support for python 3.3 that is already old